### PR TITLE
pin Azure Static Web Apps to prevent errors

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,11 +16,11 @@
     "vscode": {
       // Add the IDs of extensions you want installed when the container is created.
       "extensions": [
-        "dbaeumer.vscode-eslint",
-        "esbenp.prettier-vscode",
-        "ms-vscode.azure-account",
-        "ms-azuretools.vscode-azurestaticwebapps"
-      ],
+		"dbaeumer.vscode-eslint",
+		"esbenp.prettier-vscode",
+		"ms-vscode.azure-account@0.11.1",
+		"ms-azuretools.vscode-azurestaticwebapps@0.11.1"
+	],
       "settings": {
         "emmet.includeLanguages": {
           "javascript": "javascriptreact"


### PR DESCRIPTION
This took a bit to track down, but with these combination of pinning I was able to deploy to Azure.

This was difficult to solve because I couldn't find any documentation that explains how to pin Visual Studio Extensions. I relied on some of the comments from https://github.com/microsoft/vscode-remote-release/issues/3253 

Closes #13 

Needed follow ups:

* Create an issue for Azure Static Web apps extension to figure out the problem
* Create an issue to track the addition of documentation that explains pinning of extensions, both for Visual Studio Code as well as Dev Container files